### PR TITLE
Added the ability to look up artists and albums by id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# Visual Studio 2015 cache/options directory
+.vs/
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/iTunesSearch.Library.Tests/iTunesSearchTests.cs
+++ b/iTunesSearch.Library.Tests/iTunesSearchTests.cs
@@ -85,7 +85,7 @@ namespace iTunesSearch.Library.Tests
             iTunesSearchManager search = new iTunesSearchManager();
             long seasonId = 316075588;
             string expectedShowName = "Gilmore Girls";
-            string expectedLargeArtworkUrl = "http://is3.mzstatic.com/image/thumb/Music71/v4/8f/5c/1d/8f5c1d3d-c025-de7d-099e-6f55764e0d21/source/600x600bb.jpg";
+            string expectedLargeArtworkUrl = "http://is1.mzstatic.com/image/thumb/Music71/v4/82/28/39/8228392e-f1f9-3b64-6c0f-14ba1f958a92/source/600x600bb.jpg";
 
             //  Act
             var items = search.GetTVSeasonById(seasonId).Result;
@@ -101,7 +101,7 @@ namespace iTunesSearch.Library.Tests
         {
             //  Arrange
             iTunesSearchManager search = new iTunesSearchManager();
-            string showName = "King of the Hill";
+            string showName = "Top of the Lake";
             string countryCode = "AU"; /* Australia */
 
             //  Act
@@ -116,7 +116,7 @@ namespace iTunesSearch.Library.Tests
         {
             //  Arrange
             iTunesSearchManager search = new iTunesSearchManager();
-            string showName = "King of the Hill";
+            string showName = "Top of the Lake";
             string countryCode = "AU"; /* Australia */
 
             //  Act

--- a/iTunesSearch.Library.Tests/iTunesSearchTests.cs
+++ b/iTunesSearch.Library.Tests/iTunesSearchTests.cs
@@ -23,6 +23,21 @@ namespace iTunesSearch.Library.Tests
         }
 
         [TestMethod]
+        public void GetArtistById_InvalidArtist_ReturnsDefaultInstanceOfSongArtist()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long artistId = 5858500001;
+
+            // Act
+            var item = search.GetSongArtistByArtistIdAsync(artistId).Result;
+
+            // Assert
+            Assert.IsInstanceOfType(item, typeof(SongArtist));
+            Assert.IsTrue(item.ArtistName == default(string));
+        }
+
+        [TestMethod]
         public void GetArtistByAMGArtistId_ValidArtist_ReturnsArtist()
         {
             // Arrange
@@ -34,6 +49,49 @@ namespace iTunesSearch.Library.Tests
 
             // Assert
             Assert.IsTrue(item.ArtistName == "R.E.M.");
+        }
+
+        [TestMethod]
+        public void GetArtistByAMGArtistId_InvalidArtist_ReturnsDefaultInstanceOfSongArtist()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long amgArtistId = 5858500001;
+
+            // Act
+            var item = search.GetSongArtistByAMGArtistIdAsync(amgArtistId).Result;
+
+            // Assert
+            Assert.IsInstanceOfType(item, typeof(SongArtist));
+            Assert.IsTrue(item.ArtistName == default(string));
+        }
+
+        [TestMethod]
+        public void GetAlbumsByArtistId_ValidArtist_ReturnsAlbums()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long artistId = 311145;
+
+            // Act
+            var items = search.GetAlbumsByArtistIdAsync(artistId, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Albums.Any(al => al.CollectionName == "Life's Rich Pageant"));
+        }
+
+        [TestMethod]
+        public void GetAlbumsByAMGArtistId_ValidArtist_ReturnsAlbums()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long amgArtistId = 116437;
+
+            // Act
+            var items = search.GetAlbumsByAMGArtistIdAsync(amgArtistId, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Albums.Any(al => al.CollectionName == "Life's Rich Pageant"));
         }
 
         [TestMethod]

--- a/iTunesSearch.Library.Tests/iTunesSearchTests.cs
+++ b/iTunesSearch.Library.Tests/iTunesSearchTests.cs
@@ -9,6 +9,65 @@ namespace iTunesSearch.Library.Tests
     public class iTunesSearchTests
     {
         [TestMethod]
+        public void GetSongArtists_ValidArtists_ReturnsArtists()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            string artist = "R.E.M.";
+
+            // Act
+            var items = search.GetSongArtistsAsync(artist, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Artists.Any());
+        }
+
+        [TestMethod]
+        public void GetSongs_ValidSongs_ReturnsSongs()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            string song = "Driver 8";
+
+            // Act
+            var items = search.GetSongsAsync(song, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Songs.Any());
+            Assert.IsTrue(items.Songs.Any(s => s.TrackName == "Driver 8" && s.ArtistName == "R.E.M."));
+        }
+
+        [TestMethod]
+        public void GetAlbums_ValidAlbums_ReturnsAlbums()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            string album = "Collapse into Now";
+
+            // Act
+            var items = search.GetAlbumsAsync(album, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Albums.Any());
+            Assert.IsTrue(items.Albums.Any(al => al.ArtistName == "R.E.M."));
+        }
+
+        [TestMethod]
+        public void GetAlbumsFromSong_ValidAlbums_ReturnsAlbums()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            string song = "Driver 8";
+
+            // Act
+            var items = search.GetAlbumsFromSongAsync(song, 200).Result;
+
+            // Assert
+            Assert.IsTrue(items.Albums.Any());
+            Assert.IsTrue(items.Albums.Any(al => al.ArtistName == "R.E.M." && al.CollectionName == "Fables of the Reconstruction"));
+        }
+
+        [TestMethod]
         public void GetTVEpisodesForShow_ValidShow_ReturnsEpisodes()
         {
             //  Arrange

--- a/iTunesSearch.Library.Tests/iTunesSearchTests.cs
+++ b/iTunesSearch.Library.Tests/iTunesSearchTests.cs
@@ -9,6 +9,34 @@ namespace iTunesSearch.Library.Tests
     public class iTunesSearchTests
     {
         [TestMethod]
+        public void GetArtistById_ValidArtist_ReturnsArtist()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long artistId = 311145;
+
+            // Act
+            var item = search.GetSongArtistByArtistIdAsync(artistId).Result;
+
+            // Assert
+            Assert.IsTrue(item.ArtistName == "R.E.M.");
+        }
+
+        [TestMethod]
+        public void GetArtistByAMGArtistId_ValidArtist_ReturnsArtist()
+        {
+            // Arrange
+            iTunesSearchManager search = new iTunesSearchManager();
+            long amgArtistId = 116437;
+
+            // Act
+            var item = search.GetSongArtistByAMGArtistIdAsync(amgArtistId).Result;
+
+            // Assert
+            Assert.IsTrue(item.ArtistName == "R.E.M.");
+        }
+
+        [TestMethod]
         public void GetSongArtists_ValidArtists_ReturnsArtists()
         {
             // Arrange

--- a/iTunesSearch.Library/iTunesSearchManager.cs
+++ b/iTunesSearch.Library/iTunesSearchManager.cs
@@ -160,6 +160,11 @@ namespace iTunesSearch.Library
 
         #region Music Search
 
+        /// <summary>
+        /// Looks up an artist by its unique iTunes id.
+        /// </summary>
+        /// <param name="artistId">The artist id value.</param>
+        /// <returns></returns>
         public async Task<SongArtist> GetSongArtistByArtistIdAsync(long artistId)
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -175,6 +180,11 @@ namespace iTunesSearch.Library
             return result ?? new SongArtist();
         }
 
+        /// <summary>
+        /// Looks up an artist by its unique AMG id.
+        /// </summary>
+        /// <param name="amgArtistId">The AMG id value.</param>
+        /// <returns></returns>
         public async Task<SongArtist> GetSongArtistByAMGArtistIdAsync(long amgArtistId)
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -190,6 +200,14 @@ namespace iTunesSearch.Library
             return result ?? new SongArtist();
         }
 
+        /// <summary>
+        /// Looks up albums for an artist by its unique iTunes id.
+        /// </summary>
+        /// <param name="artistId">The artist id value.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<AlbumResult> GetAlbumsByArtistIdAsync(long artistId, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -208,6 +226,14 @@ namespace iTunesSearch.Library
             return result;
         }
 
+        /// <summary>
+        /// Looks up albums for an artist by its unique AMG id.
+        /// </summary>
+        /// <param name="amgArtistId">The AMG id value.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<AlbumResult> GetAlbumsByAMGArtistIdAsync(long amgArtistId, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -226,6 +252,14 @@ namespace iTunesSearch.Library
             return result;
         }
 
+        /// <summary>
+        /// Gets a list of artists for a given search term
+        /// </summary>
+        /// <param name="artist">The artist name to search for.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<SongArtistResult> GetSongArtistsAsync(string artist, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -246,6 +280,14 @@ namespace iTunesSearch.Library
             return result;
         }
 
+        /// <summary>
+        /// Gets a list of songs for a given search term.
+        /// </summary>
+        /// <param name="song">The song name to search for.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<SongResult> GetSongsAsync(string song, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -266,6 +308,14 @@ namespace iTunesSearch.Library
             return result;
         }
 
+        /// <summary>
+        /// Gets a list of albums for a given search term.
+        /// </summary>
+        /// <param name="album">The album name to search for.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<AlbumResult> GetAlbumsAsync(string album, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
@@ -285,6 +335,15 @@ namespace iTunesSearch.Library
 
             return result;
         }
+
+        /// <summary>
+        /// Gets a list of albums for a given search term.
+        /// </summary>
+        /// <param name="song">The song name featured in albums to search for.</param>
+        /// <param name="resultLimit">Limit the result count to this number.</param>
+        /// <param name="countryCode">The two-letter country ISO code for the store you want to search.
+        /// See http://en.wikipedia.org/wiki/%20ISO_3166-1_alpha-2 for a list of ISO country codes</param>
+        /// <returns></returns>
         public async Task<AlbumResult> GetAlbumsFromSongAsync(string song, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);

--- a/iTunesSearch.Library/iTunesSearchManager.cs
+++ b/iTunesSearch.Library/iTunesSearchManager.cs
@@ -178,11 +178,11 @@ namespace iTunesSearch.Library
             return result;
         }
 
-        public async Task<SongResult> GetSongsAsync(string artist, int resultLimit = 100, string countryCode = "us")
+        public async Task<SongResult> GetSongsAsync(string song, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);
 
-            nvc.Add("term", artist);
+            nvc.Add("term", song);
             nvc.Add("media", "music");
             nvc.Add("entity", "musicTrack");
             nvc.Add("attribute", "songTerm");

--- a/iTunesSearch.Library/iTunesSearchManager.cs
+++ b/iTunesSearch.Library/iTunesSearchManager.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Runtime.Serialization.Json;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace iTunesSearch.Library
 {
@@ -158,6 +159,37 @@ namespace iTunesSearch.Library
         #endregion TV shows
 
         #region Music Search
+
+        public async Task<SongArtist> GetSongArtistByArtistIdAsync(long artistId)
+        {
+            var nvc = HttpUtility.ParseQueryString(string.Empty);
+
+            nvc.Add("id", artistId.ToString());            
+
+            //  Construct the url:
+            string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
+
+            //  Get the list of episodes
+            var result = (await MakeAPICall<SongArtistResult>(apiUrl)).Artists.FirstOrDefault();
+
+            return result;
+        }
+
+        public async Task<SongArtist> GetSongArtistByAMGArtistIdAsync(long amgArtistId)
+        {
+            var nvc = HttpUtility.ParseQueryString(string.Empty);
+
+            nvc.Add("amgArtistId", amgArtistId.ToString());
+
+            //  Construct the url:
+            string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
+
+            //  Get the list of episodes
+            var result = (await MakeAPICall<SongArtistResult>(apiUrl)).Artists.FirstOrDefault();
+
+            return result;
+        }
+
         public async Task<SongArtistResult> GetSongArtistsAsync(string artist, int resultLimit = 100, string countryCode = "us")
         {
             var nvc = HttpUtility.ParseQueryString(string.Empty);

--- a/iTunesSearch.Library/iTunesSearchManager.cs
+++ b/iTunesSearch.Library/iTunesSearchManager.cs
@@ -169,10 +169,10 @@ namespace iTunesSearch.Library
             //  Construct the url:
             string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
 
-            //  Get the list of episodes
+            //  Get the artist
             var result = (await MakeAPICall<SongArtistResult>(apiUrl)).Artists.FirstOrDefault();
 
-            return result;
+            return result ?? new SongArtist();
         }
 
         public async Task<SongArtist> GetSongArtistByAMGArtistIdAsync(long amgArtistId)
@@ -184,8 +184,44 @@ namespace iTunesSearch.Library
             //  Construct the url:
             string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
 
-            //  Get the list of episodes
+            //  Get the artist
             var result = (await MakeAPICall<SongArtistResult>(apiUrl)).Artists.FirstOrDefault();
+
+            return result ?? new SongArtist();
+        }
+
+        public async Task<AlbumResult> GetAlbumsByArtistIdAsync(long artistId, int resultLimit = 100, string countryCode = "us")
+        {
+            var nvc = HttpUtility.ParseQueryString(string.Empty);
+
+            nvc.Add("id", artistId.ToString());
+            nvc.Add("entity", "album");
+            nvc.Add("limit", resultLimit.ToString());
+            nvc.Add("country", countryCode);
+
+            //  Construct the url:
+            string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
+
+            //  Get the albums
+            var result = await MakeAPICall<AlbumResult>(apiUrl);
+
+            return result;
+        }
+
+        public async Task<AlbumResult> GetAlbumsByAMGArtistIdAsync(long amgArtistId, int resultLimit = 100, string countryCode = "us")
+        {
+            var nvc = HttpUtility.ParseQueryString(string.Empty);
+
+            nvc.Add("amgArtistId", amgArtistId.ToString());
+            nvc.Add("entity", "album");
+            nvc.Add("limit", resultLimit.ToString());
+            nvc.Add("country", countryCode);
+
+            //  Construct the url:
+            string apiUrl = string.Format(_baseLookupUrl, nvc.ToString());
+
+            //  Get the albums
+            var result = await MakeAPICall<AlbumResult>(apiUrl);
 
             return result;
         }


### PR DESCRIPTION
Here's the full list of changes:

Added:

- Methods to look up an artist by artist id and AMG artist id
- Methods to look up albums for an artist by artist id and AMG artist id
- Tests for the new methods and for the already existed music search methods
- XML documentation for the new methods and for the already existed music search methods

Fixed:

- Some failing tests (King of the Hill has been pulled from iTunes)
- A parameter name in the GetSongsAsync method (called "artist" originally when in fact it was searching by the song name)
